### PR TITLE
Fix messagebird module issue

### DIFF
--- a/backend/lib/server.js
+++ b/backend/lib/server.js
@@ -1,5 +1,5 @@
 require('env2')('./config.env')
-const messageBird = require('messageBird')(process.env.API_KEY)
+const messageBird = require('messagebird')(process.env.API_KEY)
 
 import Hapi from 'hapi'
 const server = new Hapi.Server()


### PR DESCRIPTION
requiring messageBird with camel case breaks on ubuntu. Switching to messagebird fixes the issue.
